### PR TITLE
[Feat] 상태 코드 입력 및 상수 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const {
   DELETE_NEWTUBER_TOAST,
   DELETE_ALL_NEWTUBER_TOAST,
   CHANGE_NETUBE_CHANNEL_TOAST,
+  NOT_REQUEST_VALUE_TOAST,
 } = require('./constants');
 const express = require('express');
 const app = express();
@@ -47,22 +48,30 @@ app.get('/newtuber/:id', (req, res) => {
 
   const newtuber = db.get(id);
   if (newtuber == undefined)
-    res.json({
+    res.status(404).json({
       message: NOT_FOUND_TOAST,
     });
   else res.json(newtuber);
 });
 
 app.get('/newtubers', (req, res) => {
-  res.json(Object.fromEntries(db));
+  if (db.size < 1) res.status(404).json({ message: EMPTY_NEWTUBER_TOAST });
+  else res.json(Object.fromEntries(db));
 });
 
-app.post('/newtuber', (req, res) => {
-  db.set(idx++, req.body);
+app.post('/newtubers', (req, res) => {
+  const channelTitle = req.body.channelTitle;
+  if (channelTitle) {
+    db.set(idx++, req.body);
 
-  res.json({
-    message: SIGN_UP_TOAST(db.get(idx - 1).channelTitle, idx),
-  });
+    res.status(201).json({
+      message: SIGN_UP_TOAST(db.get(idx - 1).channelTitle, idx),
+    });
+  } else {
+    res.status(400).json({
+      message: NOT_REQUEST_VALUE_TOAST,
+    });
+  }
 });
 
 app.delete('/newtubers/:id', (req, res) => {
@@ -72,7 +81,7 @@ app.delete('/newtubers/:id', (req, res) => {
   const newtuber = db.get(id);
 
   if (newtuber == undefined)
-    res.json({
+    res.status(404).json({
       message: NOT_FOUND_TOAST,
     });
   else {
@@ -85,7 +94,7 @@ app.delete('/newtubers/:id', (req, res) => {
 
 app.delete('/newtubers', (req, res) => {
   if (db.size < 1) {
-    res.json({
+    res.status(404).json({
       message: EMPTY_NEWTUBER_TOAST,
     });
   } else {
@@ -103,7 +112,7 @@ app.put('/newtubers/:id', (req, res) => {
   const newtuber = db.get(id);
 
   if (newtuber == undefined)
-    res.json({
+    res.status(404).json({
       message: NOT_FOUND_TOAST,
     });
   else {

--- a/constants.js
+++ b/constants.js
@@ -8,6 +8,7 @@ const DELETE_NEWTUBER_TOAST = (channelTitle) =>
 const DELETE_ALL_NEWTUBER_TOAST = '모든 뉴튜버가 삭제되었습니다.';
 const CHANGE_NETUBE_CHANNEL_TOAST = (preTitle, changeTitle) =>
   `${preTitle}의 뉴튜브 채널명이 ${changeTitle}로 변경 되었습니다.`;
+const NOT_REQUEST_VALUE_TOAST = '요청 값이 정확하지 않습니다.';
 
 module.exports = {
   HELLO_WORLD_TOAST,
@@ -17,4 +18,5 @@ module.exports = {
   DELETE_NEWTUBER_TOAST,
   DELETE_ALL_NEWTUBER_TOAST,
   CHANGE_NETUBE_CHANNEL_TOAST,
+  NOT_REQUEST_VALUE_TOAST,
 };


### PR DESCRIPTION
### HTTP 상태코드

- `2**`
    - `200` 조회/수정/삭제 성공
    - `201` 등록 성공
- `4**`
    - `400` 요청한 연산(처리)을 할 때 필요한 데이터(req)가 덜 왔을 때
    - `404` 찾는 페이지(리소스) 없음 (url에 맞는 api 없음)
- `500` 서버가 죽었을 때 (서버가 크리티컬한 오류를 맞았을 때)